### PR TITLE
Updated docker-compose.yml to use local build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "5433:5432"
 
   backend:
-    image: backend:latest
+    image: ahmedhamdo/backend:latest
     environment:
       POSTGRES_URL: jdbc:postgresql://postgres:5432/petclinic
       POSTGRES_USER: petclinic
@@ -25,7 +25,7 @@ services:
       - "9966:9966"
 
   frontend:
-    image: frontend:latest
+    image: ahmedhamdo/frontend:latest
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
This pull request updates the docker-compose.yml file to pull images directly from Docker Hub, making it easier for other team members to run the application without building images locally.

Changes
Updated docker-compose.yml to reference images hosted on Docker Hub:
ahmedhamdo/backend:latest
ahmedhamdo/frontend:latest
ahmedhamdo/postgres:latest
Now, running docker compose up will pull the latest images from my Docker Hub account, simplifying the setup process for anyone cloning the repository.